### PR TITLE
Export ConnectionState so callers can tell the state of the connection

### DIFF
--- a/rmnp.go
+++ b/rmnp.go
@@ -209,7 +209,7 @@ func (impl *protocolImpl) handlePacket(addr *net.UDPAddr, packet []byte) {
 
 	// done this way to ensure that connect callback is executed on client-side
 	if descriptor(packet[5])&descConnect != 0 {
-		if connection.updateState(stateConnected) {
+		if connection.updateState(StateConnected) {
 			header := headerSize(packet)
 			invokeConnectionCallback(impl.onConnect, connection, packet[header:])
 			impl.connectGuard.finish(hash)
@@ -247,7 +247,7 @@ func (impl *protocolImpl) connectClient(addr *net.UDPAddr) *Connection {
 }
 
 func (impl *protocolImpl) disconnectClient(connection *Connection, disconnectType disconnectType, packet []byte) {
-	if !connection.updateState(stateDisconnected) {
+	if !connection.updateState(StateDisconnected) {
 		return
 	}
 


### PR DESCRIPTION
I made this adjustment as one of the first things I did while working with the library is added a way to get the state of the connection. I did so as I wanted to be able to block until the client was connected.
I will be working around to making the same change for the C# port.