### PR TITLE
Switch to xxh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ modern realtime games like first person shooters. It is basically an extension f
 
 - Connections (with timeouts and ping calculation)
 - Error detection
-- Small overhead (max 15 bytes for header)
+- Small overhead (max 19 bytes for header)
 - Simple congestion control (avoids flooding nodes between sender/receiver)
 - Optional reliable and ordered packet delivery
 
@@ -17,7 +17,7 @@ The bad thing about TCP is that once a packet is dropped it stops sending all ot
 This can be a huge problem for games that are time sensitive because it is not uncommon for devices to encounter
 packet-loss. Therefore RMNP facilitates UDP to guarantee fast delivery without any restrictions. Because UDP is stateless
 RMNP implements an easy way to handle connection and to distinguish between "connected" clients. Every packet contains a small
-header mainly containing a CRC32 hash to ensure that all received packets were transmitted correctly.
+header mainly containing an XXH hash to ensure that all received packets were transmitted correctly.
 
 To guarantee reliability the receiver sends acknowledgment packets back to tell the sender which packets it received. The sender
 resends each packet until it received an acknowledgment or the maximum timeout is reached. Because of that RMNP is not 100% reliable

--- a/example/client.go
+++ b/example/client.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/obsilp/rmnp"
 	"fmt"
+	"github.com/tim-oster/rmnp"
 )
 
 func main() {
@@ -32,5 +32,5 @@ func serverTimeout(conn *rmnp.Connection, data []byte) {
 }
 
 func handleClientPacket(conn *rmnp.Connection, data []byte, channel rmnp.Channel) {
-	fmt.Println("'" + string(data) + "'", "on channel", channel)
+	fmt.Println("'"+string(data)+"'", "on channel", channel)
 }

--- a/example/server.go
+++ b/example/server.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/obsilp/rmnp"
-	"net"
 	"fmt"
+	"github.com/tim-oster/rmnp"
+	"net"
 )
 
 func main() {

--- a/exec_guard.go
+++ b/exec_guard.go
@@ -4,16 +4,16 @@ import "sync"
 
 type execGuard struct {
 	mutex      sync.Mutex
-	executions map[uint32]bool
+	executions map[uint64]bool
 }
 
 func newExecGuard() *execGuard {
 	guard := new(execGuard)
-	guard.executions = make(map[uint32]bool)
+	guard.executions = make(map[uint64]bool)
 	return guard
 }
 
-func (g *execGuard) tryExecute(id uint32) bool {
+func (g *execGuard) tryExecute(id uint64) bool {
 	g.mutex.Lock()
 	defer g.mutex.Unlock()
 
@@ -25,7 +25,7 @@ func (g *execGuard) tryExecute(id uint32) bool {
 	return false
 }
 
-func (g *execGuard) finish(id uint32) {
+func (g *execGuard) finish(id uint64) {
 	g.mutex.Lock()
 	defer g.mutex.Unlock()
 	delete(g.executions, id)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/tim-oster/rmnp
+
+go 1.17
+
+require github.com/OneOfOne/xxhash v1.2.8

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
+github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=

--- a/packet_test.go
+++ b/packet_test.go
@@ -7,12 +7,12 @@ package rmnp
 import "testing"
 
 var testPacketDescriptors = map[descriptor]int{
-	0:                          6,
-	descReliable:               8,
-	descOrdered:                8,
-	descReliable | descOrdered: 9,
-	descAck:                    12,
-	descReliable | descOrdered | descAck: 15,
+	0:                                    10,
+	descReliable:                         12,
+	descOrdered:                          12,
+	descReliable | descOrdered:           13,
+	descAck:                              16,
+	descReliable | descOrdered | descAck: 19,
 }
 
 var testPacketDescriptorPermutations = []descriptor{
@@ -28,7 +28,7 @@ var testPacketDescriptorPermutations = []descriptor{
 func newTestPacket() *packet {
 	return &packet{
 		protocolID: CfgProtocolID,
-		crc32:      244,
+		xxh:        244,
 		descriptor: descReliable | descAck | descOrdered,
 		sequence:   10,
 		order:      5,
@@ -49,8 +49,8 @@ func TestPacketSerialization(t *testing.T) {
 		t.Error("packet.protocolId not correctly serialized")
 	}
 
-	if d.crc32 != s.crc32 {
-		t.Error("packet.crc32 not correctly serialized")
+	if d.xxh != s.xxh {
+		t.Error("packet.xxh not correctly serialized")
 	}
 
 	if d.descriptor != s.descriptor {
@@ -91,7 +91,7 @@ func TestPacketHash(t *testing.T) {
 	p1.calculateHash()
 	p2.calculateHash()
 
-	if p1.crc32 != p2.crc32 {
+	if p1.xxh != p2.xxh {
 		t.Error("Packet hashes or not equal")
 	}
 }
@@ -118,7 +118,7 @@ func TestPacketValidateHeader(t *testing.T) {
 		t.Error("Valid packet cannot be validated")
 	}
 
-	if validateHeader(d[0:5]) {
+	if validateHeader(d[0:9]) {
 		t.Error("Wrong min length for fixed header")
 	}
 

--- a/util.go
+++ b/util.go
@@ -7,7 +7,7 @@ package rmnp
 import (
 	"encoding/binary"
 	"fmt"
-	"hash/crc32"
+	"github.com/OneOfOne/xxhash"
 	"net"
 	"sync/atomic"
 	"time"
@@ -34,9 +34,9 @@ func antiPanic(callback func()) {
 	}
 }
 
-func addrHash(addr *net.UDPAddr) uint32 {
+func addrHash(addr *net.UDPAddr) uint64 {
 	port := cnvUint32(uint32(addr.Port))
-	return crc32.ChecksumIEEE(append(addr.IP, port...))
+	return xxhash.Checksum64(append(addr.IP, port...))
 }
 
 func cnvUint32(i uint32) []byte {


### PR DESCRIPTION
Hello,

I'm not sure if you're interested in this, but I recently investigated some ways of speeding up RMNP.

One way of doing this is via switching to a more modern, and faster hashing library from CRC32, which is currently XXH. It's incredibly fast for both small and large data, and it indeed makes a huge difference with a large amount of connections/packets, such as in the case of a MMORPG.

The current pure go implementation I use almost matches the reference C implementation in speed.

There are a few drawbacks:

* Due to the current XXH32 implementation's less optimized state, I opted for XXH64. This resulted in doubling the hash field in the packet headers, from uint32 to uint64, so the max packet header size now is 19 instead of 15.
* This change will make the C# port incompatible, however, I believe that there are C# implementations of XXH as well.

I've also added a go.mod file, as well as changed the package imports for the example server and client to the current one.

All tests pass, and the examples work as expected.

I'm also looking into switching away from Golang's *net* package, as the performance of the current UDP implementation could be better.